### PR TITLE
Disallow arguments of `addr` that contains the port

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ IPVS
 ```ruby
 # Create IPVS::Service instance.
 s = IPVS::Service.new({
-  'addr' => '10.0.0.1:80',
+  'addr' => '10.0.0.1',
   'port' => 80,
   'sched_name' => 'wrr'
 })

--- a/src/mrb_ipvs.c
+++ b/src/mrb_ipvs.c
@@ -19,20 +19,6 @@ int str_is_digit(const char *str) {
   return (offset < top) ? 0 : 1;
 }
 
-int string_to_number(const char *s, int min, int max) {
-  long number;
-  char *end;
-
-  errno = 0;
-  number = strtol(s, &end, 10);
-  if (*end == '\0' && end != s) {
-    /* We parsed a number, let's see if we want this. */
-    if (errno != ERANGE && min <= number && number <= max)
-      return number;
-  }
-  return -1;
-}
-
 int host_to_addr(const char *name, struct in_addr *addr) {
   struct hostent *host;
 

--- a/src/mrb_ipvs.h
+++ b/src/mrb_ipvs.h
@@ -20,7 +20,6 @@
 #include <limits.h>
 
 int str_is_digit(const char *str);
-int string_to_number(const char *s, int min, int max);
 int host_to_addr(const char *name, struct in_addr *addr);
 
 #endif

--- a/src/mrb_ipvs_dest.h
+++ b/src/mrb_ipvs_dest.h
@@ -3,7 +3,6 @@
 
 #define DEST_NONE 0x0000
 #define DEST_ADDR 0x0001
-#define DEST_PORT 0x0002
 
 #define DEF_WEIGHT 1
 #define DEF_CONN_FLAGS "NAT"

--- a/src/mrb_ipvs_service.h
+++ b/src/mrb_ipvs_service.h
@@ -3,7 +3,6 @@
 
 #define SERVICE_NONE 0x0000
 #define SERVICE_ADDR 0x0001
-#define SERVICE_PORT 0x0002
 
 #define DEF_PROTO "TCP"
 #define DEF_SCHED "wlc"


### PR DESCRIPTION
If the port is specified by `addr` (with a colon and number) and `port` in `Service` or `Dest`, `port` be given preference but not `addr`. This specification is complicated and not simple.
So, by this PR, disallow arguments of `addr` that contains the port. 
- Before

```
# setting
s = IPVS::Service.new({
  'addr' => '192.168.2.1:80',
  'port' => 443,
  'sched_name' => 'wrr'
})
# confirm settings
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
TCP  121.3.87.87:443 wrr
```
- After

```
# setting
s = IPVS::Service.new({
  'addr' => '192.168.2.1:80',
  'port' => 443,
  'sched_name' => 'wrr'
})
# confirm settings
trace:
    [0] ipvs.mrb:5
ipvs.mrb:5: invalid addr value specified (ArgumentError)
```
