### PR TITLE
Call mrb_ipvs_get_services when necessary

### DIFF
--- a/src/mrb_ipvs.c
+++ b/src/mrb_ipvs.c
@@ -69,7 +69,6 @@ static mrb_value mrb_ipvs_services(mrb_state *mrb, mrb_value self)
 {
   struct ip_vs_get_services *get;
   char pbuf[INET6_ADDRSTRLEN];
-  mrb_value argv[2];
   int i;
   ipvs_service_entry_t *se;
   mrb_value services, service, h;
@@ -94,10 +93,7 @@ static mrb_value mrb_ipvs_services(mrb_state *mrb, mrb_value self)
     mrb_hash_set(mrb, h, mrb_str_new_cstr(mrb, "port"), mrb_fixnum_value(ntohs(se->port)));
     mrb_hash_set(mrb, h, mrb_str_new_cstr(mrb, "sched_name"),
                  mrb_str_new_cstr(mrb, se->sched_name));
-
-    argv[0] = h;
-    argv[1] = mrb_false_value();
-    service = mrb_obj_new(mrb, mrb_class_get_under(mrb, mrb_class_get(mrb, "IPVS"), "Service"), 2, argv);
+    service = mrb_obj_new(mrb, mrb_class_get_under(mrb, mrb_class_get(mrb, "IPVS"), "Service"), 1, &h);
     mrb_update_service_dests(mrb, service, get);
     mrb_ary_push(mrb, services, service);
   }

--- a/src/mrb_ipvs.c
+++ b/src/mrb_ipvs.c
@@ -69,6 +69,7 @@ static mrb_value mrb_ipvs_services(mrb_state *mrb, mrb_value self)
 {
   struct ip_vs_get_services *get;
   char pbuf[INET6_ADDRSTRLEN];
+  mrb_value argv[2];
   int i;
   ipvs_service_entry_t *se;
   mrb_value services, service, h;
@@ -93,7 +94,10 @@ static mrb_value mrb_ipvs_services(mrb_state *mrb, mrb_value self)
     mrb_hash_set(mrb, h, mrb_str_new_cstr(mrb, "port"), mrb_fixnum_value(ntohs(se->port)));
     mrb_hash_set(mrb, h, mrb_str_new_cstr(mrb, "sched_name"),
                  mrb_str_new_cstr(mrb, se->sched_name));
-    service = mrb_obj_new(mrb, mrb_class_get_under(mrb, mrb_class_get(mrb, "IPVS"), "Service"), 1, &h);
+
+    argv[0] = h;
+    argv[1] = mrb_false_value();
+    service = mrb_obj_new(mrb, mrb_class_get_under(mrb, mrb_class_get(mrb, "IPVS"), "Service"), 2, argv);
     mrb_update_service_dests(mrb, service, get);
     mrb_ary_push(mrb, services, service);
   }

--- a/src/mrb_ipvs.c
+++ b/src/mrb_ipvs.c
@@ -93,6 +93,8 @@ static mrb_value mrb_ipvs_services(mrb_state *mrb, mrb_value self)
     mrb_hash_set(mrb, h, mrb_str_new_cstr(mrb, "port"), mrb_fixnum_value(ntohs(se->port)));
     mrb_hash_set(mrb, h, mrb_str_new_cstr(mrb, "sched_name"),
                  mrb_str_new_cstr(mrb, se->sched_name));
+    mrb_hash_set(mrb, h, mrb_str_new_cstr(mrb, "dests"),
+                 mrb_str_new_cstr(mrb, "dummy"));
     service = mrb_obj_new(mrb, mrb_class_get_under(mrb, mrb_class_get(mrb, "IPVS"), "Service"), 1, &h);
     mrb_update_service_dests(mrb, service, get);
     mrb_ary_push(mrb, services, service);

--- a/src/mrb_ipvs_service.c
+++ b/src/mrb_ipvs_service.c
@@ -47,9 +47,10 @@ static int parse_proto(const char *proto) {
 
 static mrb_value mrb_ipvs_service_init(mrb_state *mrb, mrb_value self) {
   int parse;
+  int argc;
   mrb_value arg_opt = mrb_nil_value(), addr = mrb_nil_value(),
             proto = mrb_nil_value(), sched_name = mrb_nil_value(),
-            obj = mrb_nil_value();
+            obj = mrb_nil_value(), read_dest = mrb_nil_value();
   // mrb_value arg_opt = mrb_nil_value(), addr = mrb_nil_value(),
   //           proto = mrb_nil_value(), sched_name = mrb_nil_value(),
   //           ops = mrb_nil_value(), obj = mrb_nil_value();
@@ -60,7 +61,10 @@ static mrb_value mrb_ipvs_service_init(mrb_state *mrb, mrb_value self) {
   ie = (struct mrb_ipvs_service *)mrb_malloc(mrb, sizeof(*ie));
   memset(ie, 0, sizeof(struct mrb_ipvs_service));
 
-  mrb_get_args(mrb, "H", &arg_opt);
+  argc = mrb_get_args(mrb, "H|o", &arg_opt, &read_dest);
+  if (argc == 1) {
+    read_dest = mrb_true_value();
+  }
 
   if (mrb_nil_p(arg_opt)) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid argument");
@@ -108,8 +112,10 @@ static mrb_value mrb_ipvs_service_init(mrb_state *mrb, mrb_value self) {
           IP_VS_SCHEDNAME_MAXLEN);
 
   mrb_data_init(self, ie, &mrb_ipvs_service_type);
-  mrb_update_service_dests(mrb, self, NULL);
 
+  if (mrb_bool(read_dest)) {
+    mrb_update_service_dests(mrb, self, NULL);
+  }
   return self;
 }
 
@@ -282,7 +288,7 @@ void mrb_ipvs_service_class_init(mrb_state *mrb, struct RClass *_class_ipvs) {
       mrb_define_class_under(mrb, _class_ipvs, "Service", mrb->object_class);
   MRB_SET_INSTANCE_TT(_class_ipvs_service, MRB_TT_DATA);
   mrb_define_method(mrb, _class_ipvs_service, "initialize",
-                    mrb_ipvs_service_init, MRB_ARGS_REQ(1));
+                    mrb_ipvs_service_init, MRB_ARGS_ARG(1, 1));
   mrb_define_method(mrb, _class_ipvs_service, "initialize_copy",
                     mrb_ipvs_service_init_copy,
                     MRB_ARGS_REQ(1) | MRB_ARGS_OPT(6));

--- a/src/mrb_ipvs_service.c
+++ b/src/mrb_ipvs_service.c
@@ -47,10 +47,9 @@ static int parse_proto(const char *proto) {
 
 static mrb_value mrb_ipvs_service_init(mrb_state *mrb, mrb_value self) {
   int parse;
-  int argc;
   mrb_value arg_opt = mrb_nil_value(), addr = mrb_nil_value(),
             proto = mrb_nil_value(), sched_name = mrb_nil_value(),
-            obj = mrb_nil_value(), read_dest = mrb_nil_value();
+            obj = mrb_nil_value();
   // mrb_value arg_opt = mrb_nil_value(), addr = mrb_nil_value(),
   //           proto = mrb_nil_value(), sched_name = mrb_nil_value(),
   //           ops = mrb_nil_value(), obj = mrb_nil_value();
@@ -61,10 +60,7 @@ static mrb_value mrb_ipvs_service_init(mrb_state *mrb, mrb_value self) {
   ie = (struct mrb_ipvs_service *)mrb_malloc(mrb, sizeof(*ie));
   memset(ie, 0, sizeof(struct mrb_ipvs_service));
 
-  argc = mrb_get_args(mrb, "H|o", &arg_opt, &read_dest);
-  if (argc == 1) {
-    read_dest = mrb_true_value();
-  }
+  mrb_get_args(mrb, "H", &arg_opt);
 
   if (mrb_nil_p(arg_opt)) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid argument");
@@ -112,10 +108,8 @@ static mrb_value mrb_ipvs_service_init(mrb_state *mrb, mrb_value self) {
           IP_VS_SCHEDNAME_MAXLEN);
 
   mrb_data_init(self, ie, &mrb_ipvs_service_type);
+  mrb_update_service_dests(mrb, self, NULL);
 
-  if (mrb_bool(read_dest)) {
-    mrb_update_service_dests(mrb, self, NULL);
-  }
   return self;
 }
 
@@ -288,7 +282,7 @@ void mrb_ipvs_service_class_init(mrb_state *mrb, struct RClass *_class_ipvs) {
       mrb_define_class_under(mrb, _class_ipvs, "Service", mrb->object_class);
   MRB_SET_INSTANCE_TT(_class_ipvs_service, MRB_TT_DATA);
   mrb_define_method(mrb, _class_ipvs_service, "initialize",
-                    mrb_ipvs_service_init, MRB_ARGS_ARG(1, 1));
+                    mrb_ipvs_service_init, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, _class_ipvs_service, "initialize_copy",
                     mrb_ipvs_service_init_copy,
                     MRB_ARGS_REQ(1) | MRB_ARGS_OPT(6));

--- a/src/mrb_ipvs_service.c
+++ b/src/mrb_ipvs_service.c
@@ -49,7 +49,7 @@ static mrb_value mrb_ipvs_service_init(mrb_state *mrb, mrb_value self) {
   int parse;
   mrb_value arg_opt = mrb_nil_value(), addr = mrb_nil_value(),
             proto = mrb_nil_value(), sched_name = mrb_nil_value(),
-            obj = mrb_nil_value();
+            obj = mrb_nil_value(), dests = mrb_nil_value();
   // mrb_value arg_opt = mrb_nil_value(), addr = mrb_nil_value(),
   //           proto = mrb_nil_value(), sched_name = mrb_nil_value(),
   //           ops = mrb_nil_value(), obj = mrb_nil_value();
@@ -108,7 +108,14 @@ static mrb_value mrb_ipvs_service_init(mrb_state *mrb, mrb_value self) {
           IP_VS_SCHEDNAME_MAXLEN);
 
   mrb_data_init(self, ie, &mrb_ipvs_service_type);
-  mrb_update_service_dests(mrb, self, NULL);
+
+
+  dests = mrb_hash_get(mrb, arg_opt, mrb_str_new_cstr(mrb, "dests"));
+  if (mrb_nil_p(dests)) {
+    mrb_update_service_dests(mrb, self, NULL);
+  } else {
+    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "@dests"), dests);
+  }
 
   return self;
 }

--- a/test/ipvs_service_test.rb
+++ b/test/ipvs_service_test.rb
@@ -20,6 +20,19 @@ assert('IPVS::Service.new({"addr" => "10.0.0.1", "sched_name" => "rr"}') do
   ipvs.sched_name == "rr"
 end
 
+assert('IPVS::Service.new({"addr" => "10.0.0.1", "dests" => {"addr" => "192.168.0.1", "weight" => 256, "port" => 80, "conn" => "dr"}') do
+  ipvs = IPVS::Service.new({
+    "addr" => "10.0.0.1",
+    "dests" => [IPVS::Dest.new({"addr" => "192.168.0.1", "weight" => 256, "port" => 80, "conn" => "dr"})]
+  })
+  dest = ipvs.dests.first
+  assert_equal(1, ipvs.dests.length)
+  assert_equal("192.168.0.1", dest.addr)
+  assert_equal(80, dest.port)
+  assert_equal(256, dest.weight)
+  assert_equal("DR", dest.conn)
+end
+
 assert('IPVS::Service#dests') do
   add_service_with do |s,d|
     dests = s[0].dests


### PR DESCRIPTION
少々内容が複雑で英語で伝える自身がないので日本語で失礼します。

# 事象
このPRを取り込むと、`IPVS::services`時のメモリ使用量を大幅に削減することが出来ます。必要となった背景としては、IPVSのレコード数が数万件規模になったときに、`IPVS::services`をコールすると、数Gメモリを消費してしまうケースがありました。

具体的には、`IPVS::services`がコールされると、ipvsから既に存在するServiceと、そのDestsを取得します。

その際にServiceクラスを[インスタンス化](https://github.com/rrreeeyyy/mruby-ipvs/blob/master/src/mrb_ipvs.c#L96)するのですが、このときにDestsクラスも[インスタンス化](https://github.com/rrreeeyyy/mruby-ipvs/blob/master/src/mrb_ipvs_service.c#L111)され、Serviceクラスのインスタンス変数として格納されます。

構造的にはこんな感じ。
```
{
  "proto"=>"TCP",
  "addr"=>"10.2.0.1",
  "port"=>10000,
  "sched_name"=>"wrr",
  # destsが子としてメンバーに居る
  "dests"=>[{"addr"=>"192.168.0.1", "port"=>80, "weight"=>1, "conn"=>"NAT"}, {"addr"=>"192.168.0.2", "port"=>80, "weight"=>1, "conn"=>"DR"}]
}
```

その際にコールされるメソッドは`mrb_update_service_dests`なのですが、その際に、ipvsのサービス情報が引き渡されない場合、メソッド内で[取得する動作](https://github.com/rrreeeyyy/mruby-ipvs/blob/master/src/mrb_ipvs_service.c#L233)があります。

この動作はipvsのサービス情報すべてを取得する処理なので、これがdests分走ってしまうと、かなりメモリを消費することになります。

# 対処
対応方法としては、`Service`クラスの初期化引数に、destsの読み込みを行うか否かのフラグを設けました。初期値はtrueです。他の対応方法としてはservice情報をキャッシュすることや、グローバル変数で持ち回る方法も考えましたが、その場合、スレッドフリーにする実装がそれなりに手間なのと複雑になるので、今回の方法を取りました。

