### PR TITLE
Remove some dead code

### DIFF
--- a/src/mrb_ipvs.c
+++ b/src/mrb_ipvs.c
@@ -94,7 +94,6 @@ static mrb_value mrb_ipvs_services(mrb_state *mrb, mrb_value self)
     mrb_hash_set(mrb, h, mrb_str_new_cstr(mrb, "sched_name"),
                  mrb_str_new_cstr(mrb, se->sched_name));
     service = mrb_obj_new(mrb, mrb_class_get_under(mrb, mrb_class_get(mrb, "IPVS"), "Service"), 1, &h);
-    mrb_update_service_dests(mrb, service);
     mrb_ary_push(mrb, services, service);
   }
 


### PR DESCRIPTION
mrb_update_service_dests in [mrb_ipvs_services](https://github.com/rrreeeyyy/mruby-ipvs/blob/master/src/mrb_ipvs.c#L97) is duplicated with [mrb_ipvs_service_init](https://github.com/rrreeeyyy/mruby-ipvs/blob/master/src/mrb_ipvs_service.c#L111)